### PR TITLE
Amend field names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,7 +451,7 @@ impl CypherText {
             buf[i] = *v;
         }
 
-        for (i, v) in self.gamma.to_bytes().iter().enumerate() {
+        for (i, v) in self.delta.to_bytes().iter().enumerate() {
             buf[i+32] = *v;
         }
 


### PR DESCRIPTION
The field `gamma` has been duplicated
in the to_bytes function for the
CypherText. This is fixed in this commit.

This is linked to issue #3 